### PR TITLE
Revert "Only load fonts on Android"

### DIFF
--- a/g2gmobile/main.js
+++ b/g2gmobile/main.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import Expo from 'expo';
-import { observer } from 'mobx-react';
-import { Platform } from 'react-native';
 
 import App from "./components/App";
 import { AppStore } from "./stores";
+
+import { observer } from 'mobx-react';
 
 const store = new AppStore();
 
@@ -12,12 +12,10 @@ const store = new AppStore();
     state = { fontsAreLoaded: false };
 
     async componentWillMount() {
-        if (Platform.OS === "android") {
-            await Expo.Font.loadAsync({
-                'Roboto': require('native-base/Fonts/Roboto.ttf'),
-                'Roboto_medium': require('native-base/Fonts/Roboto_medium.ttf'),
-            });
-        }
+        await Expo.Font.loadAsync({
+            'Roboto': require('native-base/Fonts/Roboto.ttf'),
+            'Roboto_medium': require('native-base/Fonts/Roboto_medium.ttf'),
+        });
         this.setState({fontsAreLoaded: true});
     }
 


### PR DESCRIPTION
This reverts commit 6d9be8768390ffdc73df3754a3a81ea1ef765f9c.

we still need these fonts on iOS. development blocker was worked around by everyone using yarn instead of npm.