### PR TITLE
remove max number on location

### DIFF
--- a/greentogo/templates/core/location.djhtml
+++ b/greentogo/templates/core/location.djhtml
@@ -63,7 +63,7 @@
                 <p>
                 <label for="number_of_boxes">Number of boxes</label>
                 <input class="input-group-field" name="number_of_boxes"
-                       type="number" value="1" min="1"  max="4" />
+                       type="number" value="1" min="1" />
                 </p>
 
                 <button type="submit" class="button" id="checkin-checkout-button">


### PR DESCRIPTION
remove max number to allow users with admin subscription to edit as many boxes as they want